### PR TITLE
fixed `round_digit()`

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1,12 +1,12 @@
 
 round_digit <- function (d) {
-    i <- 0
-    while (d < 1) {
-        d <- d * 10
-        i <- i + 1
+    if (d > 1) {
+        round(d)
+    } else {
+        round(d, -as.integer(floor(log10(abs(d)))))
     }
-    round(d)/10^i
 }
+
 
 
 is_fixed_radius <- function(rvar) {


### PR DESCRIPTION
no infinite loop when d <= 0,
while mainting the functionality for d>0.

```
round_digit <- function (d) {
    if (d > 1) {
        round(d)
    } else {
        round(d, -as.integer(floor(log10(abs(d)))))
    }
}
```

It rounds to `digits=0` if `d>1`
and for `d<1`, it rounds to the first decimal different from `0`. - Like the original code.
**But especially it doesn't end up in an endless loop for `d = 0` or `d < 0`!**