### PR TITLE
adjust the radius of pie legend

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,9 @@ Suggests:
     knitr,
     rmarkdown,
     prettydoc,
-    maps
+    maps,
+    scales
 VignetteBuilder: knitr
 License: Artistic-2.0
 Encoding: UTF-8
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1

--- a/R/geom_scatterpie_legend.R
+++ b/R/geom_scatterpie_legend.R
@@ -22,9 +22,14 @@ geom_scatterpie_legend <- function(radius, x, y, n=5, labeller) {
     ##     radius <- sapply(seq(min(rr), max(rr), length.out=5), roundDigit)
     ## }
 
-    if (length(radius) > n) {
-        radius <- unique(sapply(seq(min(radius), max(radius), length.out=n), round_digit))
+    #if (length(radius) > n) {
+    #    radius <- unique(sapply(seq(min(radius), max(radius), length.out=n), round_digit))
+    #}
+    if (n <= 1){
+        stop('The n argument requires larger than 1.')
     }
+
+    radius <- scales::breaks_extended(n = n)(radius)
 
     label <- FALSE
     if (!missing(labeller)) {


### PR DESCRIPTION
adjust the breaks of the radius of pie with `scales::breaks_extended`

```
library(scatterpie)
library(ggplot2)
set.seed(123)
long <- rnorm(50, sd=100)
lat <- rnorm(50, sd=50)
d <- data.frame(long=long, lat=lat)
d <- with(d, d[abs(long) < 150 & abs(lat) < 70,])
n <- nrow(d)
d$region <- factor(1:n)
d$A <- abs(rnorm(n, sd=1))
d$B <- abs(rnorm(n, sd=2))
d$C <- abs(rnorm(n, sd=3))
d$D <- abs(rnorm(n, sd=4))
d[1, 4:7] <- d[1, 4:7] * 3
d$radius <- 6 * abs(rnorm(n))
p <- ggplot() + geom_scatterpie(aes(x=long, y=lat, group=region, r=radius), data=d,
                                cols=LETTERS[1:4], color=NA) + coord_equal()
f1 <- p + geom_scatterpie_legend(d$radius, x=-140, y=-70, n=3)
f2 <- p + geom_scatterpie_legend(d$radius, x=-140, y =-70, n=8)
aplot::plot_list(f1, f2)
```
![xx](https://user-images.githubusercontent.com/17870644/188149840-5f632a53-43ef-4e6f-800c-8a7c6bb08ca3.PNG)
