### PR TITLE
Allow label customisation in scatterpie legend

### DIFF
--- a/R/geom_scatterpie_legend.R
+++ b/R/geom_scatterpie_legend.R
@@ -7,13 +7,16 @@
 ##' @param y y position
 ##' @param n number of circle
 ##' @param labeller function to label radius
+##' @param label_position a character string indicating the position of labels,
+##'   "right" (default) or "left" or any abbreviation of these
+##' @param ... other text arguments passed on to \code{\link[ggplot2:layer]{ggplot2::layer()}}
 ##' @importFrom ggplot2 aes_
 ##' @importFrom ggplot2 geom_segment
 ##' @importFrom ggplot2 geom_text
 ##' @export
 ##' @return layer
 ##' @author Guangchuang Yu
-geom_scatterpie_legend <- function(radius, x, y, n=5, labeller) {
+geom_scatterpie_legend <- function(radius, x, y, n=5, labeller, label_position = "right", ...) {
     ## rvar <- as.character(mapping)["r"]
     ## if (is_fixed_radius(rvar)) {
     ##     radius <- as.numeric(rvar)
@@ -47,9 +50,18 @@ geom_scatterpie_legend <- function(radius, x, y, n=5, labeller) {
         dd$label <- dd$r
     }
 
+    label_position <- match.arg(label_position, c("right", "left"))
+    if (label_position == "right") {
+      hjust <- "left"
+      sign <- `+`
+    } else {
+      hjust <- "right"
+      sign <- `-`
+    }
+
     list(
         geom_arc_bar(aes_(x0=~x, y0=~y, r0=~r, r=~r, start=~start, end=~end), data=dd, inherit.aes=FALSE),
-        geom_segment(aes_(x=~x, xend=~x+maxr*1.5, y=~y+r, yend=~y+r), data=dd, inherit.aes=FALSE),
-        geom_text(aes_(x=~x+maxr*1.6, y=~y+r, label=~label), data=dd, hjust='left', inherit.aes=FALSE)
+        geom_segment(aes_(x=~x, xend=~sign(x, maxr*1.5), y=~y+r, yend=~y+r), data=dd, inherit.aes=FALSE),
+        geom_text(aes_(x=~sign(x, maxr*1.6), y=~y+r, label=~label), data=dd, hjust=hjust, inherit.aes=FALSE, ... = ...)
     )
 }

--- a/man/geom_scatterpie_legend.Rd
+++ b/man/geom_scatterpie_legend.Rd
@@ -4,7 +4,15 @@
 \alias{geom_scatterpie_legend}
 \title{geom_scatterpie_legend}
 \usage{
-geom_scatterpie_legend(radius, x, y, n = 5, labeller)
+geom_scatterpie_legend(
+  radius,
+  x,
+  y,
+  n = 5,
+  labeller,
+  label_position = "right",
+  ...
+)
 }
 \arguments{
 \item{radius}{radius vector}
@@ -16,6 +24,11 @@ geom_scatterpie_legend(radius, x, y, n = 5, labeller)
 \item{n}{number of circle}
 
 \item{labeller}{function to label radius}
+
+\item{label_position}{a character string indicating the position of labels,
+"right" (default) or "left" or any abbreviation of these}
+
+\item{...}{other text arguments passed on to \code{\link[ggplot2:layer]{ggplot2::layer()}}}
 }
 \value{
 layer


### PR DESCRIPTION
In one of my projects I wanted to display the scatterpie legend labels on the left side of the legend key. This can be done in `ggplot2` legends, but I realised that it was not possible to do this for the `scatterpie` legend. I added the `label_position` argument to `geom_scatterpie_legend()` to allow this behaviour. I also added the `...` argument which allows you to customise the key labels (colour, size, font, ...). This PR introduces these arguments as I think users could benefit from greater flexibility.

Reprex (using example from the vignette):

``` r
# devtools::install_github("mattiaghilardi/scatterpie", ref = "scatterpie-legend-custom-text")
library(scatterpie)
set.seed(123)
long <- rnorm(50, sd=100)
lat <- rnorm(50, sd=50)
d <- data.frame(long=long, lat=lat)
d <- with(d, d[abs(long) < 150 & abs(lat) < 70,])
n <- nrow(d)
d$region <- factor(1:n)
d$A <- abs(rnorm(n, sd=1))
d$B <- abs(rnorm(n, sd=2))
d$C <- abs(rnorm(n, sd=3))
d$D <- abs(rnorm(n, sd=4))
d[1, 4:7] <- d[1, 4:7] * 3

d$radius <- 6 * abs(rnorm(n))
p <- ggplot() +
  geom_scatterpie(aes(x=long, y=lat, group=region, r=radius),
                  data=d,
                  cols=LETTERS[1:4], color=NA) +
  coord_equal()
p + geom_scatterpie_legend(d$radius, x=-140, y=-70)
```

![](https://i.imgur.com/gMa0OYI.png)

``` r
# legend at bottom-right with labels at left
p + geom_scatterpie_legend(d$radius, x=140, y=-70, label_position="left")
```

![](https://i.imgur.com/WoyxVug.png)

``` r
# example of label customisation: smaller text, in bold and serif font
p + geom_scatterpie_legend(d$radius, x=-140, y=-70, fontface="bold", size=3.5, family="serif")
```

![](https://i.imgur.com/EpBXzvl.png)
