### PR TITLE
color of outline can be mapped 

### DIFF
--- a/R/geom_scatterpie.R
+++ b/R/geom_scatterpie.R
@@ -70,13 +70,15 @@ geom_scatterpie <- function(mapping=NULL, data, cols, pie_scale = 1,
         mapping <- modifyList(mapping, aes_(r=size))
         if (!is.null(donut_radius)){
             donut_radius <- .check_donut_radius(donut_radius)
-            mapping <- modifyList(mapping, aes_(r0 = ~size * donut_radius))
+            data$.R0 <- size * donut_radius
+            mapping <- modifyList(mapping, aes_(r0 = ~.R0))
         }
     }else{
         if (!is.null(donut_radius)){
             rvar <- get_aes_var(mapping, 'r')
             donut_radius <- .check_donut_radius(donut_radius)
-            mapping <- modifyList(mapping, aes_(r0 = ~rvar * donut_radius))
+            data$.R0 <- data[[rvar]] * donut_radius
+            mapping <- modifyList(mapping, aes_(r0 = ~.R0))
         }
     }
 
@@ -118,10 +120,8 @@ geom_scatterpie <- function(mapping=NULL, data, cols, pie_scale = 1,
     if (!sorted_by_radius) {
         pie.layer <- geom_arc_bar(mapping, data=df, stat='pie', inherit.aes=FALSE, ...)
         if (!is.null(bg_circle_radius)){
-            mapping.circle <- mapping[names(mapping) %in% c('x0', 'y0')]
-            dt <- .extract_mapping_df(df, mapping, extract_aes = c('x0', 'y0'), col_var=rvar)
-            mapping.circle <- modifyList(mapping.circle, aes(r = !!as.symbol(rvar) * bg_circle_radius))
-            circle.layer <- geom_circle(data = dt, mapping = mapping.circle, inherit.aes=FALSE, ...)
+            circle.layer <- .add_circle_layer(data = df, mapping = mapping, rvar = rvar, 
+                                              bg_circle_radius = bg_circle_radius, ...)
             pie.layer <- list(circle.layer, pie.layer)
         }
         return(pie.layer)
@@ -132,10 +132,8 @@ geom_scatterpie <- function(mapping=NULL, data, cols, pie_scale = 1,
            {
         pie.layer <- geom_arc_bar(mapping, data=d, stat='pie', inherit.aes=FALSE, ...)
         if (!is.null(bg_circle_radius)){
-            mapping.circle <- mapping[names(mapping) %in% c('x0', 'y0', 'r')]
-            d2 <- .extract_mapping_df(d, mapping, extract_aes = c('x0', 'y0', 'r'), col_var = rvar)
-            mapping.circle <- modifyList(mapping.circle, aes(r = !!as.symbol(rvar) * bg_circle_radius))
-            circle.layer <- geom_circle(data = d2, mapping = mapping.circle, inherit.aes=FALSE, ...)
+            circle.layer <- .add_circle_layer(data = d, mapping = mapping, rvar = rvar, 
+                                              bg_circle_radius = bg_circle_radius, ...)
             pie.layer <- list(circle.layer, pie.layer)
         }
         return(pie.layer)

--- a/R/geom_scatterpie.R
+++ b/R/geom_scatterpie.R
@@ -51,6 +51,17 @@
 ##'       ) + 
 ##'       coord_fixed()
 ##' p2
+##' d |> dplyr::select(c(x, y)) |> dplyr::distinct() |> dplyr::mutate(Cell=c('A','A','B','C','B')) -> d2
+##' d |> dplyr::left_join(d2) -> d3
+##' d3$r_size <- c(2, 3, 4, 5, 6) * .01
+##' 
+##' head(d3)
+##' p3 <- ggplot() +
+##'      geom_scatterpie(data = d3, mapping = aes(x=x, y=y, r = r_size, color=Cell), cols="letters",
+##'                      long_format=T, donut_radius=.5, color = NA, linewidth=2,
+##'                       bg_circle_radius=1.2) + coord_fixed()
+##' p3
+##' 
 ##' @author Guangchuang Yu
 geom_scatterpie <- function(mapping=NULL, data, cols, pie_scale = 1, 
                             sorted_by_radius = FALSE, legend_name = "type", 

--- a/R/geom_scatterpie.R
+++ b/R/geom_scatterpie.R
@@ -58,7 +58,7 @@
 ##' head(d3)
 ##' p3 <- ggplot() +
 ##'      geom_scatterpie(data = d3, mapping = aes(x=x, y=y, r = r_size, color=Cell), cols="letters",
-##'                      long_format=T, donut_radius=.5, color = NA, linewidth=2,
+##'                      long_format=TRUE, donut_radius=.5, color = NA, linewidth=2,
 ##'                       bg_circle_radius=1.2) + coord_fixed()
 ##' p3
 ##' 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -17,6 +17,16 @@ is_fixed_radius <- function(rvar) {
     return(TRUE)
 }
 
+.add_circle_layer <- function(data, mapping, rvar, bg_circle_radius, ...){
+    mapping.circle <- mapping[names(mapping) %in% c('x0', 'y0', 'r', 'color', 'colour')]
+    dt <- .extract_mapping_df(data, mapping, extract_aes = c('x0', 'y0', 'color', 'colour'), col_var = rvar)
+    dt[[rvar]] <- dt[[rvar]] * bg_circle_radius
+    params <- list(data = dt, mapping = mapping.circle, inherit.aes = FALSE, fill = 'white', ...)
+    params <- .check_aes_in_params(params, c("color", "colour"))
+    circle.layer <- do.call(geom_circle, params)
+    return(circle.layer)
+}
+
 .check_donut_radius <- function(x){
     if (x > 1){
         cli::cli_warn("The `donut.radius` should be range 0 and 1, it was set to 0.5 automatically.")
@@ -34,4 +44,13 @@ is_fixed_radius <- function(rvar) {
     extract.var <- union(col_var, extract.var)
     df <- data[, colnames(data) %in% extract.var, drop=FALSE] |> dplyr::distinct()
     return(df)
+}
+
+.check_aes_in_params <- function(params, aes_var){
+    for (i in aes_var){
+        if (i %in% names(params)){
+            params[[i]] <- NULL
+        }
+    }
+    return(params)
 }

--- a/man/geom_scatterpie.Rd
+++ b/man/geom_scatterpie.Rd
@@ -79,7 +79,7 @@ d3$r_size <- c(2, 3, 4, 5, 6) * .01
 head(d3)
 p3 <- ggplot() +
      geom_scatterpie(data = d3, mapping = aes(x=x, y=y, r = r_size, color=Cell), cols="letters",
-                     long_format=T, donut_radius=.5, color = NA, linewidth=2,
+                     long_format=TRUE, donut_radius=.5, color = NA, linewidth=2,
                       bg_circle_radius=1.2) + coord_fixed()
 p3
 

--- a/man/geom_scatterpie.Rd
+++ b/man/geom_scatterpie.Rd
@@ -72,6 +72,17 @@ p2 <- ggplot() +
       ) + 
       coord_fixed()
 p2
+d |> dplyr::select(c(x, y)) |> dplyr::distinct() |> dplyr::mutate(Cell=c('A','A','B','C','B')) -> d2
+d |> dplyr::left_join(d2) -> d3
+d3$r_size <- c(2, 3, 4, 5, 6) * .01
+
+head(d3)
+p3 <- ggplot() +
+     geom_scatterpie(data = d3, mapping = aes(x=x, y=y, r = r_size, color=Cell), cols="letters",
+                     long_format=T, donut_radius=.5, color = NA, linewidth=2,
+                      bg_circle_radius=1.2) + coord_fixed()
+p3
+
 }
 \author{
 Guangchuang Yu


### PR DESCRIPTION
```
> d |> dplyr::select(c(x, y)) |> dplyr::distinct() |> dplyr::mutate(Cell=c('A','A','B','C','B')) -> d2

> d |> dplyr::left_join(d2) -> d3
Joining with `by = join_by(x, y)`

> d3$r_size <- c(2, 3, 4, 5, 6) * .01

> head(d3)
           x          y letters     value Cell r_size
1 -0.2587278 -0.5486010       A 0.5809584    A   0.02
2 -0.7469574  0.2471864       A 0.7770539    A   0.03
3  0.4275919  0.1282868       A 0.8052695    B   0.04
4 -1.5439724  0.6223713       A 0.5662144    C   0.05
5 -2.7569273  0.2987277       A 0.4293619    B   0.06
6 -0.2587278 -0.5486010       B 2.6691236    A   0.02

> p3 <- ggplot() +
       geom_scatterpie(data = d3, mapping = aes(x=x, y=y, r = r_size, color=Cell), cols="letters",
                       long_format=T, donut_radius=.5, color = NA, linewidth=2,
                        bg_circle_radius=1.2) + coord_fixed()

> p3
```
![image](https://github.com/GuangchuangYu/scatterpie/assets/17870644/d1802505-6794-4593-bd99-14cad69dfb41)
